### PR TITLE
Update roles, voting model

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ The Tooling Working Group's mission is to provide ROS 2 users with simple, robus
 
 This document defines the scope and governance of the ROS 2 Tooling Working Group.
 
+
 ## Meetings
 
 * Regular WG Meeting: Every other Friday at 9:00 AM Pacific Time (biweekly)
@@ -11,6 +12,7 @@ This document defines the scope and governance of the ROS 2 Tooling Working Grou
   * After the meeting we will post:
     * Video recording
     * Notes from the meeting
+
 
 ## Subprojects
 
@@ -47,12 +49,14 @@ The following subprojects are owned by Tooling WG:
     * https://github.com/ros-tooling/action-amazon-chime
     * https://github.com/ros-tooling/action-pypi
 
+
 ### Adding new subprojects
 
 To request introduction of a new subproject, use the "Add Project Request" issue template in this repository.
 
 To resolve the created ticket, a PR must be merged by a working group admin, which edits the "Subprojects" section of this document.
-The PR will be merged on a 1/2 vote (see "Voting")
+The PR will be merged on WG approval.
+
 
 ### Standards for subprojects
 
@@ -68,6 +72,7 @@ These criteria are:
 * Issues are responded to promptly
 * Releases go out regularly when bugfixes or new features are introduced
 
+
 ### Deprecating subprojects
 
 Sometimes, project may cease to be useful, or their maintainers may leave.
@@ -76,50 +81,63 @@ To request removal of a subproject, use the "Remove Project Request" issue templ
 
 To resolve the created ticket, a PR must be merged by a working group admin, which edits the "Subprojects" section of this document.
 Additionally, if the repository lives in the `ros-tooling` organization, it will be transferred or deleted out of the organization.
-The PR will be merged on a 2/3 vote (see "Voting")
+The PR will be merged on WG approval.
+
 
 ## Scope
 
 WG Tooling’s mission is to provide ROS 2 users with simple, robust and easy to use tools for recording, debugging, visualization and introspection purposes.
 
+
 ### In scope
 
 * Subprojects owned by the WG
+
 
 ### Out of scope
 
 * Middleware/communications
 
+
 ## Membership, Roles and Organization Management
 
-The roles of the WG are reflected in its Teams
+Working Group members may act in one or more of the following roles:
 
-* Members
-    * Issue triage privileges
-* Reviewers
-    * Code review privileges for a subproject
-* Approvers
-    * Code review approval and merge privileges for a subproject
-* Subproject owner
-    * Admin on a specific subproject
-* Admin
-    * Admin on organization and all its repositories
+* **Member**
+  * Attend at least one out of the last three Working Group meetings
+  * Responsible for triaging issues
+* **Reviewer**
+  * All reviewers are members
+  * Responsible for reviewing pull requests
+* **Approver**
+  * All approvers are reviewers
+  * Responsible for approving and merging pull requests
+  * Responsible for vetting and accepting new projects into the Working Group
+* **Subproject Owner**
+  * Admin for repositories for their subproject
+  * Responsible for backlog maintenance and high level direction for their subproject
+* **Lead**
+  * Leader of the working group
+  * Responsible for reviewing membership applications
+  * Responsible for breaking ties
 
 To become a member or change role, use the "Organization Membership Request" issue template on this repository.
-* `Member` will be granted automatically on request
-* `Reviewer` will be granted with approval of Subproject Owner for the relevant project
-* `Approver` will be granted with approval of Subproject Owner for the relevant project
-* `Subproject Owner` requests will be granted on adding a subproject (see "Adding New Subprojects")
+* **Member** will be granted automatically on request
+* **Reviewer** will be granted with approval of Subproject Owner for the relevant project
+* **Approver** will be granted with approval of Subproject Owner for the relevant project
+* **Subproject Owner** requests will be granted on adding a subproject (see "Adding New Subprojects")
   * Transfer of ownership of a subproject will be granted on approval of the existing Subproject Owner, it uses the same membership issue template.
-* `Admin` requests will be granted on a 2/3 vote (see "Voting")
+
+
+## WG Approval / Voting
+
+This Working Group aims to operate by consensus.
+Issues needing a group decision will be discussed at the recurring meeting.
+When consensus cannot be reached, decisions should in most cases be made by resource commitment: e.g. if a member wants to dedicate their resources to the completion of a goal, then they may do so.
+In cases where consensus cannot be reached and resource commitment is insufficient or inappropriate, simple majority voting is used, with each member having one vote.
+
 
 ## Modifying this governance document
 
 Changes to this document will be made via Pull Request.
-The PR will be merged on a 1/2 vote (see "Voting")
-
-## Voting
-
-In this document, any call for a X/Y vote means the following:
-
-At the next meeting of the working group, the Members in attendance will vote, and if >= X/Y of the voters vote in favor, the motion passes.
+The PR will be merged on WG approval.


### PR DESCRIPTION
* Make role definitions match more closely with  https://github.com/ros-security/community
* Simplify voting model by following the TSC Charter from https://index.ros.org/doc/ros2/Governance/