### PR TITLE
Add robag2-bag-v2 repo to the rosbag2 subproject

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The following subprojects are owned by Tooling WG:
     * @Karsten1987
   * Repositories
     * https://github.com/ros2/rosbag2
+    * https://github.com/ros2/rosbag2_bag_v2
 * System Metrics Collector
   * Description: a set of composable nodes that collect a set of host system metrics and publish them to the ROS system for analysis
   * Owners


### PR DESCRIPTION
# Modify Project

* What modification is being made to a Working Group Subproject?
  * Adding the `rosbag2_bag_v2`  repository to the rosbag2 subproject
* Why?
  * this plugin supports playing bag ROS bags in ROS 2 so it's an important part of the ecosystem
  * changes in rosbag2 can break it
  * built by same authors

In your changes, you have modified the relevant "Subprojects" section list item in `README.md`.
