### PR TITLE
Add rcpputils subproject

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ The following subprojects are owned by Tooling WG:
   * Repositories
     * https://github.com/ros2/rosbag2
     * https://github.com/ros2/rosbag2_bag_v2
+* rcpputils
+  * Description: A C++ library consisting of macros, functions, and data structures intended for use in ROS2 packages.
+  * Repositories: https://github.com/ros2/rcpputils
 * System Metrics Collector
   * Description: a set of composable nodes that collect a set of host system metrics and publish them to the ROS system for analysis
   * Repositories


### PR DESCRIPTION
Signed-off-by: Prajakta Gokhale <prajaktg@amazon.com>

# Add Project

## Description
* What is this tool?
`rcpputils` repository contains utility C++ macros, functions and data structures taht are intended to be used in ROS2 packages.

* Why should this tool be maintained by the Working Group?
Since the repository has C++ tools that are used by ROS2 developers, it fits the criteria for being maintained by the Tooling WG.