### PR TITLE
Add a script that manages team permissions to all org repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ The Tooling Working Group's mission is to provide ROS 2 users with simple, robus
 
 This document defines the scope and governance of the ROS 2 Tooling Working Group.
 
+NOTE: The `scripts` directory in this repository contains scripts used to manage this organization and keep it up to date with any settings/permissions laid out in this document.
+
 
 ## Subprojects
 

--- a/scripts/setup-permissions.py
+++ b/scripts/setup-permissions.py
@@ -1,0 +1,99 @@
+import os
+import sys
+
+import requests
+
+"""
+This script sets up team access to all repositories in the organization according to
+the level of permissions/responsibility set out in the governance model.
+
+To use it, you must have a github access token with "admin:org" and "repo" permissions,
+as this script reads repositories and sets permissions for teams, which uses org-level APIs
+
+Workflow:
+
+export GITHUB_TOKEN=your_token
+python3 setup-permissions.py
+"""
+
+
+try:
+    GITHUB_TOKEN = os.environ['GITHUB_TOKEN']
+except KeyError:
+    print('Environment variable GITHUB_TOKEN needs to be set')
+    sys.exit(1)
+
+ORGANIZATION = 'ros-tooling'
+TEAM_PERMISSIONS = {
+    'members': 'triage',
+    # 'push' is equivalent to what the GUI shows as 'write'
+    # reviewers need to have write access to be listed as CODEOWNERS
+    # for automatic reviewer assignment
+    'reviewers': 'push',
+    'approvers': 'maintain',
+    'owners': 'admin',
+}
+
+
+def check_request(request):
+    """Check if a request had a good return code and raise if it doesn't."""
+    if request.status_code == 200:
+        return request.json()
+    elif request.status_code == 204:
+        return request
+    else:
+        raise RuntimeError('Request failed with code {}'.format(request.status_code))
+
+
+def github_request(rest_method, endpoint, params=None):
+    """Make an authenticated request to the GitHub API using the correct REST method."""
+    headers = {'Authorization': 'token {}'.format(GITHUB_TOKEN)}
+    print('Requesting {}({}) with params {}'.format(rest_method, endpoint, params))
+    request = rest_method(
+        'https://api.github.com/{}'.format(endpoint),
+        headers=headers,
+        json=params
+    )
+    return check_request(request)
+
+
+def github_post(endpoint, params):
+    return github_request(requests.post, endpoint, params)
+
+
+def github_put(endpoint, params):
+    return github_request(requests.put, endpoint, params)
+
+
+def github_get(endpoint):
+    return github_request(requests.get, endpoint)
+
+
+def list_repos(org):
+    """Return a list of the repositories under an organization."""
+    return github_get('orgs/{}/repos'.format(org))
+
+
+def set_team_permission(org, team, repo, permission):
+    """For a given team in an organization, set its permissions for a repository."""
+    return github_put(
+        'orgs/{}/teams/{}/repos/{}/{}'.format(org, team, org, repo),
+        {'permission': permission})
+
+
+def setup_repo(org, repo):
+    """For a repository, set up all the correct team permissions."""
+    for team, permission in TEAM_PERMISSIONS.items():
+        print(set_team_permission(org, team, repo, permission))
+
+
+def main():
+    repos = list_repos('ros-tooling')
+    for repo_object in repos:
+        repo_name = repo_object['name']
+        print('Setting up {}'.format(repo_name))
+        setup_repo('ros-tooling', repo_name)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/setup-permissions.py
+++ b/scripts/setup-permissions.py
@@ -88,11 +88,11 @@ def setup_repo(org, repo):
 
 
 def main():
-    repos = list_repos('ros-tooling')
+    repos = list_repos(ORGANIZATION)
     for repo_object in repos:
         repo_name = repo_object['name']
         print('Setting up {}'.format(repo_name))
-        setup_repo('ros-tooling', repo_name)
+        setup_repo(ORGANIZATION, repo_name)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Modify Governance Model

Adding a quick note about the `scripts` directory that I am creating here.

Since the scripts are directly tied to the information set out in the governance model, this location seems most appropriate for them. Anyone in the org with maintain permissions (approvers) should be able to run this script. I have already done so to set up proper access rights for all repositories (which unblocks us from using CODEOWNERS, which requires that the code owners have write permissions on repos they are to be auto-assigned as reviewers to)
