### PR TITLE
Propose new ros-github-scripts subproject

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ The following subprojects are owned by Tooling WG:
   * Description: A ROS 2 `launch` extension that starts Nodes in their own containers
   * Repositories
     * https://github.com/ros-tooling/launch_ros_sandbox
+* ros-github-scripts
+  * Description: Collection of scripts for easier management of ROS projects on GitHub - including generating reports of contributions for TSC members, and starting Jenkins ci_launcher jobs for pull requests.
+  * Repositories
+    * https://github.com/ros-tooling/ros-github-scripts
 
 
 ### Adding new subprojects


### PR DESCRIPTION
# Add Project

## Description

**What is this tool?**

My team has been privately maintaining a set of scripts to manage our interaction with ROS projects on GitHub - these are probably useful to others involved in ROS 2. The two scripts that would initially be added are 
* `ci-for-prs`: create a `ros2.repos` gist for one or more GitHub PRs, invoke `ci_launcher` from ci.ros2.org, and comment the build status badges on the corresponding PRs. access to ci.ros2.org is limited, but this can save effort for those who do have access. additionally, others requesting review can provide the script invocation command for the reviewer to easily paste and run
*  `generate-contribution-report`: specify some set of github users, a time period, and a filter for organizations/repositories - query and format a report of contributions suitable for presentation to the ROS 2 TSC, or inward reporting within a developer's company

**Why should this tool be maintained by the Working Group?**

These utilities reduce friction around contributor interaction with the ROS2 project.
