### PR TITLE
Remove action-amazon-chime

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ The following subprojects are owned by Tooling WG:
     * https://github.com/ros-tooling/action-ros-ci-template
     * https://github.com/ros-tooling/action-ros-lint
     * https://github.com/ros-tooling/setup-ros
-    * https://github.com/ros-tooling/action-amazon-chime
     * https://github.com/ros-tooling/action-pypi
 * launch_ros_sandbox
   * Description: A ROS 2 `launch` extension that starts Nodes in their own containers


### PR DESCRIPTION
# Deprecate Project

* Which Subproject are we removing from the scope of the Working Group?

https://github.com/ros-tooling/action-amazon-chime

* Why?

This was never within the charter of the "ROS" Tooling WG - it was created at the beginning of the WG, before there was a process for vetting additions to the org.

### Followup actions needed

* [X] Archive the repository for a settling-in period. (it's been archived for a while now)
* [ ] Delete the repository or find a new owner and transfer it.

