### PR TITLE
Add Infrastructure section and repo-configs repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Its meetings and membership are largely focused on the direction, design, and wo
 ### Subproject list
 
 The following subprojects are owned by Tooling WG:
+* Tooling WG Management Infrastructure
+  * Description: Set of repositories used to manage the working group itself, not a released product
+  * Repositories
+    * https://github.com/ros-tooling/repo-configs
 * ros-cross-compile
   * Description: A tool to build ROS/ROS2 workspaces for various target platforms.
   * Repositories


### PR DESCRIPTION
# Add Project

## Description
* What is this tool?

This is the infrastructure section, with a single repo added (new repo `repo-configs` - will need to be created)

* Why should this tool be maintained by the Working Group?

This is for maintaining the WG assets more easily

