### PR TITLE
Add keyboard_handler project

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,11 @@ The following subprojects are owned by Tooling WG:
 * `topic_tools`
   * Description: Package containing tools for manipulating ROS topics - such as multiplexing, relaying, and throttling
   * Repositories:
-    * https://github.com/ros-tooling/topic_tools 
+    * https://github.com/ros-tooling/topic_tools
+* `keyboard_handler`
+  * Description: A lightweight cross-platform keyboard handling library with ROS integration
+  * Repositories:
+    * https://github.com/ros-tooling/keyboard_handler    
 
 
 ### Adding new subprojects


### PR DESCRIPTION
# Add Project

## Description
* What is this tool?

A cross-platform lightweight keyboard handling library with ROS integration.

* Why should this tool be maintained by the Working Group?

We would like to use this tool for rosbag2 commandline keyboard control. It may also come in handy for other keyboard-based ROS utilities, like key teleop
