### PR TITLE
Add libstatisticscollector project

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,12 @@ The following subprojects are owned by Tooling WG:
 * `keyboard_handler`
   * Description: A lightweight cross-platform keyboard handling library with ROS integration
   * Repositories:
-    * https://github.com/ros-tooling/keyboard_handler    
+    * https://github.com/ros-tooling/keyboard_handler  
+* `libstatistics_collector`
+  * Description: Package containing utilities for aggregating statistics in a common way. Used by rclcpp topic statistics and potentially others
+  * Repositories:
+    * https://github.com/ros-tooling/libstatistics_collector  
+    * https://github.com/ros-tooling/libstatistics_collector-release 
 
 
 ### Adding new subprojects


### PR DESCRIPTION
# Add Project

## Description

`libstatistics_collector` is a library we are already maintaining, which is a dependency of `rclcpp`, used for simple statistics aggregation such as running mean, median, stddev. Developed for topic statistics, usable in other capacities.

Adding to governance model with the aim of having all org repos tracked explicitly in this doc