### PR TITLE
Replace matrix with Discourse in communications channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,7 @@ If the repositories of the subproject are in the `ros-tooling` organization, the
 
 ### Communication Channels
 
-The WG hosts a Matrix channel for text based chat at https://matrix.to/#/!IQcVAivBdnSuEniBZa:matrix.org?via=matrix.org
-
-Some users use the Riot clients to connect to this chat room.
+The WG uses the `wg-tooling` tag on ROS Discourse: https://discourse.ros.org/tag/wg-tooling.
 
 
 ### Backlog Management


### PR DESCRIPTION
Closes #37 

We don't really use Matrix anymore. Instead, mention the `wg-tooling` tag on ROS Discourse.